### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,8 +201,22 @@
 </div>
 <footer class="footer">
     <div class="container">
-		<div class='text-center'>Copyright © 2015 Apache Software Foundation. All rights reserved. | 
-			Site template created by Jasen Kim (<a href="http://www.ydotm.com">YDOTM</a>)</div>
+		<div class='text-center'>
+			<p>Copyright © 2015-2026 The Apache Software Foundation. Licensed under the
+			<a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.</p>
+			<p>Apache Tcl, Apache Rivet, Apache, the Apache logo, and the Apache Tcl project logo are either
+			registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
+			<p>
+			<a href="https://www.apache.org/">Foundation</a> |
+			<a href="https://www.apache.org/events/current-event.html">Events</a> |
+			<a href="https://www.apache.org/licenses/">License</a> |
+			<a href="https://www.apache.org/security/">Security</a> |
+			<a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+			<a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+			<a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
+			</p>
+			<p>Site template created by Jasen Kim (<a href="http://www.ydotm.com">YDOTM</a>)</p>
+		</div>
     </div>
 </footer>
 <script src="templates/ydotm/bootstrap3.js" type="text/javascript"></script>


### PR DESCRIPTION
The Apache Tcl website is failing 8 of 9 ASF website policy checks (https://whimsy.apache.org/site/):

- Foundation link (missing)
- Events (missing)
- License (missing)
- Thanks (missing from footer)
- Security (missing)
- Sponsorship (existing sidebar link labeled "ASF Sponsorship" points to thanks.html instead of sponsorship.html)
- Trademarks (missing)
- Privacy (missing)

This updates the footer on the front page to include:
- Copyright with correct date range
- Trademark attribution for Apache Tcl and Apache Rivet
- All required ASF policy links

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/